### PR TITLE
Add Websocket request support

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.8
+current_version = 1.0.9
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/oauth2_lib/__init__.py
+++ b/oauth2_lib/__init__.py
@@ -13,4 +13,4 @@
 
 """This is the SURF Oauth2 module that interfaces with the oauth2 setup."""
 
-__version__ = "1.0.8"
+__version__ = "1.0.9"

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -260,6 +260,24 @@ async def test_OIDCUser():
 
 
 @pytest.mark.asyncio
+async def test_OIDCUser_with_token():
+
+    mock_request = mock.MagicMock(spec=Request)
+    mock_request.headers = {"Authorization": "Bearer creds"}
+
+    async def mock_introspect_token(client, token):
+        return user_info_matching
+
+    openid_bearer = OIDCUser("openid_url", "id", "secret")
+    openid_bearer.openid_config = OIDCConfig.parse_obj(discovery)
+    openid_bearer.introspect_token = mock_introspect_token  # type:ignore
+
+    result = await openid_bearer(mock_request, token="creds")
+
+    assert result == user_info_matching
+
+
+@pytest.mark.asyncio
 async def test_OIDCUser_incompatible_schema():
     mock_request = mock.MagicMock(spec=Request)
     mock_request.headers = {"Authorization": "basic creds"}


### PR DESCRIPTION
- add optional token param to be able to directly pass a token in `OIDCUser`.
- change opa_decision to be able to handle websocket request, it doesn't have a `.json` and `.method`.
- add a test for calling OIDCUser with token.
- renamed `async_client` param to `async_request` in `OIDCUser` to be consistent with `opa_decision` and to not override the `def async_request`.