### PR TITLE
Python 3.9 compatibility + Tests AsyncAuthMixin

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.7
+current_version = 1.2.8
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.9', '3.10', '3.11']
       fail-fast: false
 
     steps:

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -41,7 +41,7 @@ jobs:
           apache-license-check --copyright "2019-`date +%Y` SURF" oauth2_lib
       - name: Test with pytest
         run: |
-          pytest -vvv --cov-branch --cov-fail-under=58 --cov=oauth2_lib --cov-config=.coveragerc --junitxml=report-pytest-${{ matrix.python-version }}.xml
+          pytest -vvv --cov-branch --cov-fail-under=80 --cov=oauth2_lib --cov-config=.coveragerc --junitxml=report-pytest-${{ matrix.python-version }}.xml
       - name: Upload pytest test results
         uses: actions/upload-artifact@v2
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,27 +1,27 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.0
+    rev: v3.3.2
     hooks:
       - id: pyupgrade
         args:
-          - --py310-plus
+          - --py39-plus
           - --keep-runtime-typing
   - repo: https://github.com/timothycrosley/isort
     rev: 5.12.0
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 23.3.0
     hooks:
       - id: black
-        language_version: python3.10
+        language_version: python3.9
   - repo: https://github.com/asottile/blacken-docs
-    rev: v1.12.1
+    rev: 1.13.0
     hooks:
       - id: blacken-docs
         additional_dependencies: [black==22.10.0]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -33,7 +33,7 @@ repos:
       - id: requirements-txt-fixer
       - id: detect-private-key
   - repo: https://github.com/pycqa/flake8
-    rev: 3.9.2
+    rev: 6.0.0
     hooks:
       - id: flake8
         additional_dependencies:
@@ -48,27 +48,27 @@ repos:
           - flake8-rst-docstrings
           - flake8-tidy-imports
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.982
+    rev: v1.2.0
     hooks:
       - id: mypy
-        language_version: python3.10
+        language_version: python3.9
         additional_dependencies: [pydantic]
         args:
           - --no-warn-unused-ignores
           - --allow-untyped-decorators
         exclude: (test/*|migrations/*)
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.9.0
+    rev: v1.10.0
     hooks:
       - id: python-check-blanket-noqa
       - id: python-use-type-annotations
       - id: python-check-mock-methods
       - id: rst-backticks
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.8.0.4
+    rev: v0.9.0.2
     hooks:
       - id: shellcheck
   - repo: https://github.com/andreoliwa/nitpick
-    rev: v0.31.0
+    rev: v0.33.1
     hooks:
       - id: nitpick

--- a/README.md
+++ b/README.md
@@ -32,3 +32,11 @@ bumpversion patch
 
 ## For MAC users looking and experimenting with Opentelemetry (OTEL)
 https://github.com/jaegertracing/jaeger-client-node/issues/124#issuecomment-324222456
+
+## Supported Python versions
+
+oauth2-lib must support the same python versions as [orchestrator-core](https://github.com/workfloworchestrator/orchestrator-core).
+
+Exceptions to this rule are:
+* **A new python version is released:** oauth2-lib should support the new version before orchestrator-core does
+* **Support for an old python version is dropped:** oauth2-lib should drop the python version after orchestrator-core does

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # OAuth2-lib
+
+[![pypi_version](https://img.shields.io/pypi/v/oauth2-lib?color=%2334D058&label=pypi%20package)](https://pypi.org/project/oauth2-lib)
+[![Supported python versions](https://img.shields.io/pypi/pyversions/oauth2-lib.svg?color=%2334D058)](https://pypi.org/project/oauth2-lib)
+
 This Project contains a Mixin class that wraps an openapi-codegen python client, to inject Opentelemetry spans
 and api call retries. It also contains a number of FastAPI dependencies which enables Policy enforcement offloading
 to Open Policy Agent.

--- a/oauth2_lib/__init__.py
+++ b/oauth2_lib/__init__.py
@@ -13,4 +13,4 @@
 
 """This is the SURF Oauth2 module that interfaces with the oauth2 setup."""
 
-__version__ = "1.2.7"
+__version__ = "1.2.8"

--- a/oauth2_lib/async_api_client.py
+++ b/oauth2_lib/async_api_client.py
@@ -14,7 +14,7 @@ import contextlib
 from asyncio import new_event_loop
 from collections.abc import Generator
 from http import HTTPStatus
-from typing import Any
+from typing import Any, Union
 
 import structlog
 import urllib3
@@ -93,7 +93,7 @@ class AsyncAuthMixin:
 
     """
 
-    _token: dict | None
+    _token: Union[dict, None]
 
     def __init__(
         self,

--- a/oauth2_lib/fastapi.py
+++ b/oauth2_lib/fastapi.py
@@ -11,9 +11,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import re
+from collections.abc import AsyncGenerator, Coroutine, Mapping
 from http import HTTPStatus
 from json import JSONDecodeError
-from typing import Any, AsyncGenerator, Callable, Coroutine, Mapping, cast
+from typing import Any, Callable, Union, cast
 
 from fastapi.exceptions import HTTPException
 from fastapi.param_functions import Depends
@@ -168,7 +169,7 @@ class OIDCUser(HTTPBearer):
         2. When receiving an active token it will enrich the response through the database roles
     """
 
-    openid_config: OIDCConfig | None = None
+    openid_config: Union[OIDCConfig, None] = None
     openid_url: str
     resource_server_id: str
     resource_server_secret: str
@@ -181,7 +182,7 @@ class OIDCUser(HTTPBearer):
         resource_server_secret: str,
         enabled: bool = True,
         auto_error: bool = True,
-        scheme_name: str | None = None,
+        scheme_name: Union[str, None] = None,
     ):
         super().__init__(auto_error=auto_error)
         self.openid_url = openid_url
@@ -190,7 +191,7 @@ class OIDCUser(HTTPBearer):
         self.enabled = enabled
         self.scheme_name = scheme_name or self.__class__.__name__
 
-    async def __call__(self, request: Request, token: str | None = None) -> OIDCUserModel | None:  # type: ignore
+    async def __call__(self, request: Request, token: Union[str, None] = None) -> Union[OIDCUserModel, None]:  # type: ignore
         """
         Return the OIDC user from OIDC introspect endpoint.
 
@@ -285,13 +286,13 @@ def opa_decision(
     oidc_security: OIDCUser,
     enabled: bool = True,
     auto_error: bool = True,
-    opa_kwargs: Mapping[str, str] | None = None,
-) -> Callable[[Request, OIDCUserModel, AsyncClient], Coroutine[Any, Any, bool | None]]:
+    opa_kwargs: Union[Mapping[str, str], None] = None,
+) -> Callable[[Request, OIDCUserModel, AsyncClient], Coroutine[Any, Any, Union[bool, None]]]:
     async def _opa_decision(
         request: Request,
         user_info: OIDCUserModel = Depends(oidc_security),
         async_request: AsyncClient = Depends(async_client),
-    ) -> bool | None:
+    ) -> Union[bool, None]:
         """
         Check OIDCUserModel against the OPA policy.
 
@@ -372,12 +373,12 @@ def opa_graphql_decision(
     _oidc_security: OIDCUser,
     enabled: bool = True,
     auto_error: bool = True,
-    opa_kwargs: Mapping[str, str] | None = None,
-) -> Callable[[str, OIDCUserModel], Coroutine[Any, Any, bool | None]]:
+    opa_kwargs: Union[Mapping[str, str], None] = None,
+) -> Callable[[str, OIDCUserModel], Coroutine[Any, Any, Union[bool, None]]]:
     async def _opa_decision(
         path: str,
         oidc_user: OIDCUserModel = Depends(_oidc_security),
-    ) -> bool | None:
+    ) -> Union[bool, None]:
         """
         Check OIDCUserModel against the OPA policy.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,9 @@ classifiers = [
     "Intended Audience :: Telecommunications Industry",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.9",
 ]
 requires = [
     "requests>=2.19.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,12 +62,14 @@ test = [
     "flake8-tidy-imports",
     "isort",
     "mypy",
+    "opentelemetry-instrumentation-urllib3",
     "pygments",
     "pytest",
     "pytest-asyncio",
     "pytest-cov",
     "pytest-xdist",
     "requests_mock",
+    "urllib3_mock==0.3.3",
 ]
 dev = ["bumpversion", "pre-commit"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ classifiers = [
 ]
 requires = [
     "requests>=2.19.0",
-    "ruamel.yaml~=0.16.10",
     "structlog>=20.2.0",
     "fastapi>=0.90.1",
     "opentelemetry-distro",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ requires = [
     "pydantic>=1.8.0",
 ]
 description-file = "README.md"
-requires-python = ">3.8"
+requires-python = ">=3.9"
 
 [tool.flit.metadata.urls]
 Documentation = "https://workfloworchestrator.org/"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 import pytest
 from httpx import AsyncClient, Response
+from urllib3_mock import Responses
 
 
 @pytest.fixture(scope="session")
@@ -23,3 +24,72 @@ def make_mock_async_client():
         return mock_async_client
 
     return _make_mock_async_client
+
+
+@pytest.fixture(autouse=False)
+def responses():
+    responses_mock = Responses("requests.packages.urllib3")
+
+    def _find_request(call):
+        if not (mock_url := responses_mock._find_match(call.request)):
+            raise Exception(f"Call not mocked: {call.request}")
+        return mock_url
+
+    def _to_tuple(url_mock):
+        return (url_mock["url"], url_mock["method"], url_mock["match_querystring"])
+
+    with responses_mock:
+        yield responses_mock
+
+        mocked_urls = map(_to_tuple, responses_mock._urls)
+        used_urls = map(_to_tuple, map(_find_request, responses_mock.calls))
+        if not_used := set(mocked_urls) - set(used_urls):
+            pytest.fail(f"Found unused responses mocks: {not_used}", pytrace=False)
+
+
+@pytest.fixture(scope="session")
+def tracing():
+    from opentelemetry import trace
+    from opentelemetry.instrumentation.urllib3 import URLLib3Instrumentor
+    from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    resource = Resource(attributes={SERVICE_NAME: "oauth2-lib-unittests"})
+
+    provider = TracerProvider(resource=resource)
+
+    # Uncomment to print processed spans to stdout
+
+    # from opentelemetry.sdk.trace.export import ConsoleSpanExporter
+    # console_exporter = ConsoleSpanExporter()
+    # console_processor = BatchSpanProcessor(console_exporter)
+    # provider.add_span_processor(console_processor)
+
+    in_memory_exporter = InMemorySpanExporter()
+    in_memory_processor = BatchSpanProcessor(in_memory_exporter)
+    provider.add_span_processor(in_memory_processor)
+
+    trace.set_tracer_provider(provider)
+
+    def strip_query_params(url: str) -> str:
+        return url.split("?")[0]
+
+    # Remove all query params from the URL attribute on the span
+    URLLib3Instrumentor().instrument(url_filter=strip_query_params)
+
+    # Return the in-memory-processor so we can inspect the generated spans
+    yield in_memory_processor
+
+    try:
+        provider.shutdown()
+    except Exception as exc:
+        print("Error shutting down TracerProvider, ignoring:", str(exc))  # noqa: T201
+
+
+@pytest.fixture(autouse=True)
+def clear_spans(tracing):
+    # The tracerprovider runs the entire test-session so we have to clean up the spans
+    # after each test
+    tracing.span_exporter.clear()

--- a/tests/test_async_api_client.py
+++ b/tests/test_async_api_client.py
@@ -1,0 +1,223 @@
+import json
+from http import HTTPStatus
+from unittest import mock
+
+import pytest
+import urllib3
+from opentelemetry.sdk.trace import ReadableSpan
+from urllib3_mock import Responses
+
+from oauth2_lib.async_api_client import AsyncAuthMixin
+
+EXPIRED_TOKEN = "expired token"  # noqa: S105
+
+VALID_TOKEN = "valid token"  # noqa: S105
+
+BASE_URL = "http://my-api"
+
+
+class ApiException(Exception):
+    # Copy of OpenAPI's ApiException class
+
+    def __init__(self, status=None, reason=None, http_resp=None):
+        if http_resp:
+            self.status = http_resp.status
+            self.reason = http_resp.reason
+            self.body = http_resp.data
+            self.headers = http_resp.headers
+        else:
+            self.status = status
+            self.reason = reason
+            self.body = None
+            self.headers = None
+
+    def __str__(self):
+        error_message = "({})\n" "Reason: {}\n".format(self.status, self.reason)
+        if self.headers:
+            error_message += f"HTTP response headers: {self.headers}\n"
+
+        if self.body:
+            error_message += f"HTTP response body: {self.body}\n"
+
+        return error_message
+
+
+def make_api_client(url=BASE_URL, token=VALID_TOKEN):
+    """Create an api client similar to these.
+
+    > ims_api_client = ImsApiClient(
+    >     oauth_client=oauth_client_credentials,
+    >     oauth_client_name="<hidden>",
+    >     oauth_active=oauth2_settings.OAUTH2_ACTIVE_REQUESTS,
+    >     host=external_service_settings.IMS_URI,
+    > )
+    """
+
+    class FakeApiClient:
+        # Simplified OpenApi Client
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def request(self, method, url, query_params, headers, *args):
+            http = urllib3.PoolManager()
+            response = http.request(method, url, headers=headers)
+            if not 200 <= response.status <= 299:
+                raise ApiException(http_resp=response)
+            return response
+
+    class FakeFinalApiClient(AsyncAuthMixin, FakeApiClient):
+        # Simplified client implementation of the OpenApi Client
+        def __init__(self, host, *args, **kwargs):
+            config = mock.MagicMock()
+            config.host = host
+            config.access_token = None
+            config.access_token = None
+
+            async def mock_fetch_access_token():
+                return {"access_token": VALID_TOKEN}
+
+            base_oauth_client = mock.MagicMock()
+            oauth_client = mock.MagicMock()
+            oauth_client.fetch_access_token = mock_fetch_access_token
+            base_oauth_client.actualclient = oauth_client
+            super().__init__(
+                oauth_client=base_oauth_client,
+                oauth_client_name="actualclient",
+                oauth_active=True,
+                tracing_enabled=True,
+                configuration=config,
+            )
+
+            self._token = {"access_token": token}
+
+    return FakeFinalApiClient(url)
+
+
+class ApiMock:
+    def __init__(self, responses: Responses):
+        self.responses = responses
+
+    def get_endpoint(self):
+        def verify_token(request):
+            if request.headers["Authorization"] == f"bearer {VALID_TOKEN}":
+                return HTTPStatus.OK, {}, json.dumps({"data": "hello"})
+
+            if request.headers["Authorization"] == f"bearer {EXPIRED_TOKEN}":
+                return HTTPStatus.UNAUTHORIZED, {}, json.dumps({"error": "unauthorized"})
+
+            unrecognized_token = request.headers["Authorization"]
+            raise AssertionError(f"Invalid access token {unrecognized_token}")
+
+        self.responses.add_callback("GET", "/app/endpoint", callback=verify_token, content_type="application/json")
+
+    def get_endpoint_500(self):
+        self.responses.add(
+            "GET",
+            "/app/endpoint",
+            body=json.dumps({"error": "unknown"}),
+            status=HTTPStatus.INTERNAL_SERVER_ERROR,
+            content_type="application/json",
+        )
+
+    def get_endpoint_404(self):
+        self.responses.add(
+            "GET",
+            "/app/endpoint",
+            body=json.dumps({"error": "not found"}),
+            status=HTTPStatus.NOT_FOUND,
+            content_type="application/json",
+        )
+
+
+def test_asyncauthmixin_request_200(tracing, responses):
+    """Test that making a request with valid token works."""
+
+    # given
+    client = make_api_client()
+
+    apimock = ApiMock(responses)
+    apimock.get_endpoint()
+
+    # when
+    res = client.request("GET", f"{BASE_URL}/app/endpoint")
+
+    # then
+    assert res.status == HTTPStatus.OK
+    assert len(responses.calls) == 1
+
+    tracing.force_flush()  # Force finish the spans
+
+    spans = tracing.span_exporter._finished_spans  # type: ignore
+    assert len(spans) == 1
+    span: ReadableSpan = spans[0]
+    assert span.attributes["http.status_code"] == HTTPStatus.OK
+    assert span.attributes["http.url"] == f"{BASE_URL}/app/endpoint"
+
+
+def test_asyncauthmixin_request_401_then_200(tracing, responses):
+    """Test that a request with expired token is retried with a valid token."""
+    # given
+    client = make_api_client(token=EXPIRED_TOKEN)
+    apimock = ApiMock(responses)
+    apimock.get_endpoint()
+
+    # when
+    res = client.request("GET", f"{BASE_URL}/app/endpoint")
+
+    # then
+    assert res.status == HTTPStatus.OK
+    assert len(responses.calls) == 2
+
+    tracing.force_flush()  # Force finish the spans
+    spans = tracing.span_exporter._finished_spans  # type: ignore
+
+    assert len(spans) == 1
+    span: ReadableSpan = spans[0]
+    assert span.attributes["http.status_code"] == HTTPStatus.OK
+    assert span.attributes["http.url"] == f"{BASE_URL}/app/endpoint"
+
+
+def test_asyncauthmixin_request_500(tracing, responses):
+    # given
+    client = make_api_client(token=EXPIRED_TOKEN)
+    apimock = ApiMock(responses)
+    apimock.get_endpoint_500()
+
+    # when
+    with pytest.raises(ApiException) as exc:
+        client.request("GET", f"{BASE_URL}/app/endpoint")
+
+    # then
+    assert exc.value.status == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert len(responses.calls) == 1
+
+    tracing.force_flush()  # Force finish the spans
+    spans = tracing.span_exporter._finished_spans  # type: ignore
+
+    assert len(spans) == 1
+    span: ReadableSpan = spans[0]
+    assert span.attributes["http.status_code"] == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert span.attributes["http.url"] == f"{BASE_URL}/app/endpoint"
+
+
+def test_asyncauthmixin_request_404(tracing, responses):
+    # given
+    client = make_api_client(token=EXPIRED_TOKEN)
+    apimock = ApiMock(responses)
+    apimock.get_endpoint_404()
+
+    # when
+    with pytest.raises(ApiException) as exc:
+        client.request("GET", f"{BASE_URL}/app/endpoint")
+
+    # then
+    assert exc.value.status == HTTPStatus.NOT_FOUND
+    assert len(responses.calls) == 1
+
+    tracing.force_flush()  # Force finish the spans
+    spans = tracing.span_exporter._finished_spans  # type: ignore
+
+    assert len(spans) == 1
+    span: ReadableSpan = spans[0]
+    assert span.attributes["http.status_code"] == HTTPStatus.NOT_FOUND
+    assert span.attributes["http.url"] == f"{BASE_URL}/app/endpoint"

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -297,7 +297,7 @@ async def test_OIDCUser_no_creds_no_error():
     openid_bearer.openid_config = OIDCConfig.parse_obj(discovery)
     openid_bearer.introspect_token = mock_introspect_token  # type:ignore
 
-    result = await openid_bearer(mock_request, None)  # type:ignore
+    result = await openid_bearer(mock_request, None)
 
     assert result is None
 


### PR DESCRIPTION
* Add python 3.9 support again, include 3.9 and 3.11 to CI tests
* Increase testcoverage by testing AsyncAuthMixin including the generated OTEL traces
* Remove dependency `ruamel.yaml` which is not imported anywhere
* Bump version to 1.2.8