### PR TITLE
Httpx perf

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.3
+current_version = 1.3.4
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/oauth2_lib/__init__.py
+++ b/oauth2_lib/__init__.py
@@ -13,4 +13,4 @@
 
 """This is the SURF Oauth2 module that interfaces with the oauth2 setup."""
 
-__version__ = "1.3.3"
+__version__ = "1.3.4"

--- a/oauth2_lib/async_api_client.py
+++ b/oauth2_lib/async_api_client.py
@@ -108,10 +108,9 @@ class AsyncAuthMixin:
         """
         if self._token and not force:
             return
-        if force:
-            self._token = await self._oauth_client.fetch_access_token()
-        else:
-            self._token = await self._oauth_client.fetch_access_token()
+
+        logger.debug("Acquiring new access token", force=force)
+        self._token = await self._oauth_client.fetch_access_token()
 
     def request(  # type:ignore
         self,

--- a/oauth2_lib/fastapi.py
+++ b/oauth2_lib/fastapi.py
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import re
+import ssl
 from collections.abc import AsyncGenerator, Awaitable, Mapping
 from http import HTTPStatus
 from json import JSONDecodeError
@@ -26,6 +27,8 @@ from starlette.requests import ClientDisconnect
 from structlog import get_logger
 
 logger = get_logger(__name__)
+
+HTTPX_SSL_CONTEXT = ssl.create_default_context()  # https://github.com/encode/httpx/issues/838
 
 
 class OIDCUserModel(dict):
@@ -133,8 +136,8 @@ class OIDCUserModel(dict):
         return self.get("surf-crm-id", "")
 
 
-async def async_client() -> AsyncGenerator[AsyncClient, None]:
-    async with AsyncClient(http1=True) as client:
+async def _make_async_client() -> AsyncGenerator[AsyncClient, None]:
+    async with AsyncClient(http1=True, verify=HTTPX_SSL_CONTEXT) as client:
         yield client
 
 
@@ -319,7 +322,7 @@ def opa_decision(
     async def _opa_decision(
         request: Request,
         user_info: OIDCUserModel = Depends(oidc_security),
-        async_request: AsyncClient = Depends(async_client),
+        async_request: AsyncClient = Depends(_make_async_client),
     ) -> Union[bool, None]:
         """Check OIDCUserModel against the OPA policy.
 
@@ -405,8 +408,9 @@ def opa_graphql_decision(
             }
         }
 
-        client_request = async_request if async_request else async_request_1
-        client_request = client_request if client_request else AsyncClient(http1=True)
+        client_request = async_request or async_request_1
+        if not client_request:
+            client_request = AsyncClient(http1=True, verify=HTTPX_SSL_CONTEXT)
 
         decision = await _get_decision(client_request, opa_url, opa_input)
 


### PR DESCRIPTION
* Add `oauth2_lib.fastapi.HTTPX_SSL_CONTEXT`, use it in `httpx.AsyncClient(verify=HTTPX_SSL_CONTEXT)` everywhere
* Small refactor of `opa_graphql_decision`
* Refactor `OIDCUser.__call__` (create scoped AsyncClient instance, early exit)
* Bump to 1.3.4