### PR TITLE
Add Python 3.12 support

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.4.2
+current_version = 1.5.0
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         pydantic-version: ['1.*', '2.*']
       fail-fast: false
 

--- a/oauth2_lib/__init__.py
+++ b/oauth2_lib/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 SURF.
+# Copyright 2019-2024 SURF.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/oauth2_lib/__init__.py
+++ b/oauth2_lib/__init__.py
@@ -13,4 +13,4 @@
 
 """This is the SURF Oauth2 module that interfaces with the oauth2 setup."""
 
-__version__ = "1.4.2"
+__version__ = "1.5.0"

--- a/oauth2_lib/async_api_client.py
+++ b/oauth2_lib/async_api_client.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 SURF.
+# Copyright 2019-2024 SURF.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/oauth2_lib/fastapi.py
+++ b/oauth2_lib/fastapi.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 SURF.
+# Copyright 2019-2024 SURF.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -215,13 +215,15 @@ class OIDCUser(HTTPBearer):
         async with AsyncClient(http1=True, verify=HTTPX_SSL_CONTEXT) as async_request:
             await self.check_openid_config(async_request)
 
-            if not token:
+            if token is None:
                 credentials = await super().__call__(request)
                 if not credentials:
                     return None
-                token = credentials.credentials
+                token_or_credentials = credentials.credentials
+            else:
+                token_or_credentials = token
 
-            user_info = await self.introspect_token(async_request, token)
+            user_info = await self.introspect_token(async_request, token_or_credentials)
 
             if "active" not in user_info:
                 logger.error("Token doesn't have the mandatory 'active' key, probably caused by a caching problem")

--- a/oauth2_lib/settings.py
+++ b/oauth2_lib/settings.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 SURF.
+# Copyright 2019-2024 SURF.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/oauth2_lib/strawberry.py
+++ b/oauth2_lib/strawberry.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 SURF.
+# Copyright 2019-2024 SURF.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Intended Audience :: Telecommunications Industry",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.9",
@@ -33,14 +34,14 @@ requires = [
     "requests>=2.19.0",
     "structlog>=20.2.0",
     "fastapi>=0.90.1",
-    "httpx[http2]==0.23.0",
+    "httpx[http2]>=0.23.0,<0.27.0",
     "authlib==1.0.1",
     "pydantic",
     "strawberry-graphql>=0.171.1",
     "asyncstdlib",
 ]
 description-file = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.9,<3.13"
 
 [tool.flit.metadata.urls]
 Documentation = "https://workfloworchestrator.org/"


### PR DESCRIPTION
* Add Python 3.12 to CI and package metadata
* Loosen `httpx` constraint from `==0.23.0` to `>=0.23,<0.27.0`
* Bump package version from 1.4.2 to 1.5.0

Closes #59