### PR TITLE
Add `auto_error` parameter and fix authorization bug

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.1
+current_version = 2.0.2
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/oauth2_lib/__init__.py
+++ b/oauth2_lib/__init__.py
@@ -13,4 +13,4 @@
 
 """This is the SURF Oauth2 module that interfaces with the oauth2 setup."""
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"

--- a/oauth2_lib/fastapi.py
+++ b/oauth2_lib/fastapi.py
@@ -218,7 +218,7 @@ class OIDCAuth(Authentication):
                     return None
 
                 if token is None:
-                    token_or_extracted_id_token = await self.id_token_extractor.extract(request, auto_error=True)
+                    token_or_extracted_id_token = await self.id_token_extractor.extract(request, auto_error=True) or ""
                 else:
                     token_or_extracted_id_token = token
 

--- a/oauth2_lib/fastapi.py
+++ b/oauth2_lib/fastapi.py
@@ -263,7 +263,7 @@ class Authorization(ABC):
     """
 
     @abstractmethod
-    async def authorize(self, request: HTTPConnection, user: Optional[OIDCUserModel] = None) -> Optional[bool]:
+    async def authorize(self, request: HTTPConnection, user: OIDCUserModel) -> Optional[bool]:
         pass
 
 
@@ -274,7 +274,7 @@ class GraphqlAuthorization(ABC):
     """
 
     @abstractmethod
-    async def authorize(self, request: RequestPath, user: Optional[OIDCUserModel] = None) -> Optional[bool]:
+    async def authorize(self, request: RequestPath, user: OIDCUserModel) -> Optional[bool]:
         pass
 
 
@@ -324,7 +324,7 @@ class OPAAuthorization(Authorization, OPAMixin):
     Uses OAUTH2 settings and request information to authorize actions.
     """
 
-    async def authorize(self, request: HTTPConnection, user_info: Optional[OIDCUserModel] = None) -> Optional[bool]:
+    async def authorize(self, request: HTTPConnection, user_info: OIDCUserModel) -> Optional[bool]:
         if not (oauth2lib_settings.OAUTH2_ACTIVE and oauth2lib_settings.OAUTH2_AUTHORIZATION_ACTIVE):
             return None
 
@@ -380,7 +380,7 @@ class GraphQLOPAAuthorization(GraphqlAuthorization, OPAMixin):
         # By default don't raise HTTP 403 because partial results are preferred
         super().__init__(opa_url, auto_error, opa_kwargs)
 
-    async def authorize(self, request: RequestPath, user_info: Optional[OIDCUserModel] = None) -> Optional[bool]:
+    async def authorize(self, request: RequestPath, user_info: OIDCUserModel) -> Optional[bool]:
         if not (oauth2lib_settings.OAUTH2_ACTIVE and oauth2lib_settings.OAUTH2_AUTHORIZATION_ACTIVE):
             return None
 

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -149,13 +149,11 @@ async def test_extract_token_success():
 
 
 @pytest.mark.asyncio
-async def test_extract_token_failure():
+async def test_extract_token_returns_none():
     request = mock.MagicMock()
     request.headers = {}
     extractor = HttpBearerExtractor()
-    with pytest.raises(HTTPException) as exc_info:
-        await extractor.extract(request)
-    assert exc_info.value.status_code == 403, "Expected HTTP 403 error for missing token"
+    assert await extractor.extract(request) is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Description:**
When `is_bypassable_request` decides to bypass a request for any reason, it sends `None` to the `authorize` function in the Authorization classes. This causes a bug because the `authorize` function expects a user as a dict.

I also made the `authenticate` function more explicit about the `id_token_extractor`. It used to raise an exception when it couldn't find a token in the header. I removed the line that returned `None` after this, as it wasn't necessary. 
The function is already set to raise an exception when it can't find a token, so that code wasn't needed.

**Changes Made**
- Added `auto_error` parameter to the `extract` method in `IdTokenExtractor`.
- Updated `HttpBearerExtractor` to use the `auto_error` parameter.
- Fixed bug where bypassable requests sent `None` to the `authorize` function, causing authorization failures.
- Made the `authenticate` method explicit about `id_token_extractor` and removed unnecessary lines that returned `None`.