### PR TITLE
Update authlib to 1.6.6, drop pydantic v1 settings support 

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.5.0
+current_version = 2.6.0
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,22 +1,22 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.1
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
         args:
           - --py311-plus
           - --keep-runtime-typing
   - repo: https://github.com/psf/black
-    rev: 24.10.0
+    rev: 26.1.0
     hooks:
       - id: black
   - repo: https://github.com/asottile/blacken-docs
-    rev: 1.19.1
+    rev: 1.20.0
     hooks:
       - id: blacken-docs
         additional_dependencies: [black==24.10.0]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
         exclude: .bumpversion.cfg
@@ -30,7 +30,7 @@ repos:
       - id: detect-private-key
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.8.4
+    rev: v0.14.13
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix, --show-fixes ]
@@ -42,6 +42,6 @@ repos:
       - id: python-check-mock-methods
       - id: rst-backticks
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.10.0.1
+    rev: v0.11.0.1
     hooks:
       - id: shellcheck

--- a/oauth2_lib/__init__.py
+++ b/oauth2_lib/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2025 SURF.
+# Copyright 2019-2026 SURF.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/oauth2_lib/__init__.py
+++ b/oauth2_lib/__init__.py
@@ -13,4 +13,4 @@
 
 """This is the SURF Oauth2 module that interfaces with the oauth2 setup."""
 
-__version__ = "2.5.0"
+__version__ = "2.6.0"

--- a/oauth2_lib/async_api_client.py
+++ b/oauth2_lib/async_api_client.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2025 SURF.
+# Copyright 2019-2026 SURF.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/oauth2_lib/async_api_client.py
+++ b/oauth2_lib/async_api_client.py
@@ -112,7 +112,7 @@ class AsyncAuthMixin:
         logger.debug("Acquiring new access token", force=force)
         self._token = await self._oauth_client.fetch_access_token()
 
-    def request(  # type:ignore
+    def request(  # type: ignore
         self,
         method,
         url,
@@ -127,20 +127,20 @@ class AsyncAuthMixin:
 
         try:
             self.add_client_creds_token_header(headers)
-            return super().request(  # type:ignore
+            return super().request(  # type: ignore
                 method, url, query_params, headers, post_params, body, _preload_content, _request_timeout
             )
         except Exception as ex:
-            if is_api_exception(ex) and ex.status in (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN):  # type:ignore
+            if is_api_exception(ex) and ex.status in (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN):  # type: ignore
                 logger.warning("Access Denied. Token expired? Retrying.", api_exception=str(ex))
                 loop = new_event_loop()
                 loop.run_until_complete(self.refresh_client_creds_token(force=True))
                 self.add_client_creds_token_header(headers)
 
-                return super().request(  # type:ignore
+                return super().request(  # type: ignore
                     method, url, query_params, headers, post_params, body, _preload_content, _request_timeout
                 )
-            if is_api_exception(ex) and ex.status == HTTPStatus.NOT_FOUND:  # type:ignore
+            if is_api_exception(ex) and ex.status == HTTPStatus.NOT_FOUND:  # type: ignore
                 logger.debug(ex, url=url)  # noqa: G200
                 raise
             logger.exception("Could not call API.", client=self.__class__.__name__)

--- a/oauth2_lib/fastapi.py
+++ b/oauth2_lib/fastapi.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2025 SURF.
+# Copyright 2019-2026 SURF.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/oauth2_lib/settings.py
+++ b/oauth2_lib/settings.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2025 SURF.
+# Copyright 2019-2026 SURF.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/oauth2_lib/settings.py
+++ b/oauth2_lib/settings.py
@@ -12,12 +12,8 @@
 # limitations under the License.
 
 
-from pydantic import VERSION, Field
-
-if VERSION >= "2.0":
-    from pydantic_settings import BaseSettings
-else:
-    from pydantic import BaseSettings  # type: ignore[no-redef]
+from pydantic import Field
+from pydantic_settings import BaseSettings
 
 
 class Oauth2LibSettings(BaseSettings):

--- a/oauth2_lib/strawberry.py
+++ b/oauth2_lib/strawberry.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2025 SURF.
+# Copyright 2019-2026 SURF.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ requires = [
     "structlog>=20.2.0",
     "fastapi>=0.90.1",
     "httpx[http2]>=0.23.0",
-    "authlib==1.3.1",
+    "authlib==1.6.6",
     "pydantic>=2",
     "pydantic-settings",
     "strawberry-graphql>=0.171.1",

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -14,7 +14,7 @@ from tests.conftest import MockResponse
 
 user_info = {"active": True, "uids": ["boers"], "updated_at": 1582810910, "scope": "openid test:scope", "sub": "hoi"}
 
-user_info_matching: OIDCUserModel = {  # type:ignore
+user_info_matching: OIDCUserModel = {  # type: ignore
     "active": True,
     "edumember_is_member_of": ["urn:collab:org:surf.nl"],
     "eduperson_entitlement": ["urn:mace:surfnet.nl:surfnet.nl:sab:role:role0"],


### PR DESCRIPTION
Long overdue update of authlib to address CVEs.

Bump oauth2lib version from 2.5.0 to 2.6.0

Closes #73 
Closes #65 
Closes #49 