### PR TITLE
Fix HTTP status for unauthenticated requests

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.6.1
+current_version = 2.7.0
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/oauth2_lib/__init__.py
+++ b/oauth2_lib/__init__.py
@@ -13,4 +13,4 @@
 
 """This is the SURF Oauth2 module that interfaces with the oauth2 setup."""
 
-__version__ = "2.6.1"
+__version__ = "2.7.0"

--- a/oauth2_lib/fastapi.py
+++ b/oauth2_lib/fastapi.py
@@ -23,7 +23,7 @@ from fastapi.security.http import HTTPAuthorizationCredentials, HTTPBearer
 from httpx import AsyncClient, NetworkError
 from pydantic import BaseModel
 from starlette.requests import ClientDisconnect, HTTPConnection
-from starlette.status import HTTP_403_FORBIDDEN
+from starlette.status import HTTP_401_UNAUTHORIZED
 from starlette.websockets import WebSocket
 from structlog import get_logger
 
@@ -204,7 +204,7 @@ class OIDCAuth(Authentication):
             return None
 
         if not token:
-            raise HTTPException(status_code=HTTP_403_FORBIDDEN, detail="Not authenticated")
+            raise HTTPException(status_code=HTTP_401_UNAUTHORIZED, detail="Not authenticated")
 
         async with AsyncClient(http1=True, verify=HTTPX_SSL_CONTEXT) as async_client:
             await self.check_openid_config(async_client)

--- a/oauth2_lib/strawberry.py
+++ b/oauth2_lib/strawberry.py
@@ -243,6 +243,6 @@ def authenticated_federated_field(  # type: ignore
         resolver=resolver,  # type: ignore
         deprecation_reason=deprecation_reason,
         permission_classes=[IsAuthenticatedForQuery, IsAuthorizedForQuery] + permissions,
-        requires=requires,
+        requires=requires,  # type: ignore
         **kwargs,
     )

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -202,7 +202,7 @@ async def test_authenticate_token_extraction_failure(make_mock_async_client, dis
 
         with pytest.raises(HTTPException) as exc_info:
             await oidc_auth.authenticate(request)
-            assert exc_info.value.status_code == 403
+            assert exc_info.value.status_code == 401
             assert exc_info.value.detail == "Not authenticated"
 
 
@@ -221,5 +221,5 @@ async def test_unauthenticated_websocket_request_raises_403(oidc_auth):
     with pytest.raises(HTTPException) as exc_info:
         await oidc_auth.authenticate(websocket)
 
-    assert exc_info.value.status_code == 403, "Expected HTTP 403 error for unauthenticated websocket request"
+    assert exc_info.value.status_code == 401, "Expected HTTP 401 error for unauthenticated websocket request"
     assert exc_info.value.detail == "Not authenticated"


### PR DESCRIPTION
Confusingly, status 401 Unauthorized is intended for unauthenticated users, and 403 Forbidden is intended for an authenticated user who is not authorized to access a given resource.

This ensures the correct status is returned for unauthenticated users.

Closes #76 